### PR TITLE
Improve performance of endianness correction

### DIFF
--- a/src/FastIDs.TypeId/TypeId.Core/TypeIdParser.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeIdParser.cs
@@ -1,4 +1,6 @@
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace FastIDs.TypeId;
 
@@ -7,8 +9,14 @@ internal static class TypeIdParser
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void FormatUuidBytes(Span<byte> bytes)
     {
-        (bytes[0], bytes[3]) = (bytes[3], bytes[0]);
-        (bytes[1], bytes[2]) = (bytes[2], bytes[1]);
+        // Optimized version of:
+        // (bytes[0], bytes[3]) = (bytes[3], bytes[0]);
+        // (bytes[1], bytes[2]) = (bytes[2], bytes[1]);
+        var num = Unsafe.ReadUnaligned<uint>(ref MemoryMarshal.GetReference(bytes[..4]));
+        num = BinaryPrimitives.ReverseEndianness(num);
+        Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(bytes[..4]), num);
+        
+        // Using permutations here because benchmarks show that they are faster for uint16.
         (bytes[4], bytes[5]) = (bytes[5], bytes[4]);
         (bytes[6], bytes[7]) = (bytes[7], bytes[6]);
     }


### PR DESCRIPTION
Reading the first 4 bytes of GUID and using BinaryPrimitives showed performance improvement over the permutation.
Permutations are still faster for reversing the endianness of uint16 parts.
