### PR TITLE
Use SIMD to optimize validation of long prefixes

### DIFF
--- a/src/FastIDs.TypeId/TypeId.Benchmarks/InternalBenchmarks/AlphabetValidationBenchmarks.cs
+++ b/src/FastIDs.TypeId/TypeId.Benchmarks/InternalBenchmarks/AlphabetValidationBenchmarks.cs
@@ -1,18 +1,23 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
 
 namespace FastIDs.TypeId.Benchmarks.InternalBenchmarks;
 
 [MemoryDiagnoser]
 public class AlphabetValidationBenchmarks
 {
-    [Params(3, 6, 10, 30, 63)]
+    [Params(3, 6, 10, 16, 30, 63)]
     public int PrefixLength;
-
+    
     private string _prefix = "";
     
     private const string AlphabetStr = "abcdefghijklmnopqrstuvwxyz";
     private readonly HashSet<char> _alphabetSet = new(AlphabetStr);
-    
+    private const int LoopIterationsCount = 100_000;
+    private const int UnrollValue = 4;
+
     [GlobalSetup]
     public void Setup()
     {
@@ -24,46 +29,82 @@ public class AlphabetValidationBenchmarks
         }
     }
     
-    [Benchmark]
-    public bool AlphabetStringBenchmark()
-    {
-        var isValid = false;
-        for (var i = 0; i < 1_000_000; i++)
-        {
-            foreach (var c in _prefix)
-            {
-                isValid = AlphabetStr.Contains(c);
-            }    
-        }
-
-        return isValid;
-    }
-    
-    [Benchmark]
-    public bool AlphabetSetBenchmark()
-    {
-        var isValid = false;
-        for (var i = 0; i < 1_000_000; i++)
-        {
-            foreach (var c in _prefix)
-            {
-                isValid = _alphabetSet.Contains(c);
-            }    
-        }
-
-        return isValid;
-    }
-    
     [Benchmark(Baseline = true)]
-    public bool CharCheckBenchmark()
+    public bool CharCheck()
     {
         var isValid = false;
-        for (var i = 0; i < 1_000_000; i++)
+        for (var i = 0; i < LoopIterationsCount; i++)
         {
             foreach (var c in _prefix)
             {
-                isValid = c is >= 'a' and <= 'z';
+                isValid &= c is >= 'a' and <= 'z';
             }
+        }
+
+        return isValid;
+    }
+    
+    [Benchmark]
+    public bool Simd()
+    {
+        var isValid = false;
+        for (var i = 0; i < LoopIterationsCount; i++)
+        {
+            var lower = new Vector<short>((short)'a');
+            var higher = new Vector<short>((short)'z');
+
+            var shorts = MemoryMarshal.Cast<char, short>(_prefix.AsSpan());
+            
+            for (var j = 0; j < shorts.Length; j += Vector<short>.Count)
+            {
+                var span = Vector<short>.Count < shorts.Length - j
+                    ? shorts.Slice(j, Vector<short>.Count)
+                    : shorts[^Vector<short>.Count..];
+
+                var curVector = new Vector<short>(span);
+
+                var isGreater = Vector.GreaterThanOrEqualAll(curVector, lower);
+                var isLower = Vector.LessThanOrEqualAll(curVector, higher);
+                isValid &= isGreater && isLower;
+            }
+        }
+
+        return isValid;
+    }
+    
+    [Benchmark]
+    public bool CharCheckUnroll()
+    {
+        var isValid = false;
+        for (var i = 0; i < LoopIterationsCount; i++)
+        {
+            if (_prefix.Length < UnrollValue)
+            {
+                foreach (var c in _prefix)
+                {
+                    isValid &= c is >= 'a' and <= 'z';
+                }
+            }
+            else
+            {
+                var j = 0;
+                ref var prefixStart = ref MemoryMarshal.GetReference(_prefix.AsSpan());
+                
+                // unroll loop
+                for (; j + UnrollValue < _prefix.Length; j += UnrollValue)
+                {
+                    isValid &= Unsafe.Add(ref prefixStart, j) is >= 'a' and <= 'z';
+                    isValid &= Unsafe.Add(ref prefixStart, j + 1) is >= 'a' and <= 'z';
+                    isValid &= Unsafe.Add(ref prefixStart, j + 2) is >= 'a' and <= 'z';
+                    isValid &= Unsafe.Add(ref prefixStart, j + 3) is >= 'a' and <= 'z';
+                }
+                
+                for (; j < _prefix.Length; j++)
+                {
+                    isValid &= Unsafe.Add(ref prefixStart, j) is >= 'a' and <= 'z';
+                }
+            }
+            
         }
 
         return isValid;

--- a/src/FastIDs.TypeId/TypeId.Core/TypeIdParser.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeIdParser.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -20,9 +21,17 @@ internal static class TypeIdParser
         (bytes[4], bytes[5]) = (bytes[5], bytes[4]);
         (bytes[6], bytes[7]) = (bytes[7], bytes[6]);
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool ValidateTypeAlphabet(ReadOnlySpan<char> type)
+    {
+        return Vector.IsHardwareAccelerated && type.Length >= Vector<ushort>.Count
+            ? ValidateTypeAlphabetVectorized(type)
+            : ValidateTypeAlphabetSequential(type);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool ValidateTypeAlphabetSequential(ReadOnlySpan<char> type)
     {
         foreach (var c in type)
         {
@@ -30,6 +39,33 @@ internal static class TypeIdParser
                 return false;
         }
 
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool ValidateTypeAlphabetVectorized(ReadOnlySpan<char> type)
+    {
+        var lower = new Vector<ushort>('a');
+        var upper = new Vector<ushort>('z');
+
+        var shorts = MemoryMarshal.Cast<char, ushort>(type);
+        for (var i = 0; i < shorts.Length; i += Vector<ushort>.Count)
+        {
+            var span = Vector<ushort>.Count < shorts.Length - i
+                ? shorts.Slice(i, Vector<ushort>.Count)
+                : shorts[^Vector<ushort>.Count..];
+            
+            var curVector = new Vector<ushort>(span);
+            
+            var isGreater = Vector.GreaterThanOrEqualAll(curVector, lower);
+            if (!isGreater)
+                return false;
+            
+            var isLower = Vector.LessThanOrEqualAll(curVector, upper);
+            if (!isLower)
+                return false;
+        }
+        
         return true;
     }
 }

--- a/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/TestCases.cs
+++ b/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/TestCases.cs
@@ -37,6 +37,7 @@ public static class TestCases
         new("préfix_00000000000000000000000000") { TestName = "The prefix can only have ascii letters" },
         new("  prefix_00000000000000000000000000") { TestName = "The prefix can't have any spaces" },
         new("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl_00000000000000000000000000") { TestName = "The prefix can't be 64 characters, it needs to be 63 characters or less" },
+        new("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij0_00000000000000000000000000") { TestName = "The long prefix can't have numbers" },
         new("_00000000000000000000000000") { TestName = "If the prefix is empty, the separator should not be there" },
         new("_") { TestName = "A separator by itself should not be treated as the empty string" },
         new("prefix_1234567890123456789012345") { TestName = "The suffix can't be 25 characters, it needs to be exactly 26 characters" },


### PR DESCRIPTION
Benchmarks show an up to 5x speedup in validation of prefixes that are longer than Vector<ushort>.Length characters. The actual speedup depends on SIMD instructions on the target machine.