### PR TITLE
Implement Formattable interfaces

### DIFF
--- a/src/FastIDs.TypeId/TypeId.Core/Base32Constants.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/Base32Constants.cs
@@ -5,6 +5,8 @@ namespace FastIDs.TypeId;
 internal static class Base32Constants
 { 
     public const string Alphabet = "0123456789abcdefghjkmnpqrstvwxyz";
+
+    public static ReadOnlySpan<byte> Utf8Alphabet => "0123456789abcdefghjkmnpqrstvwxyz"u8;
     
     public static readonly SearchValues<char> AlphabetValues = SearchValues.Create(Alphabet);
     

--- a/src/FastIDs.TypeId/TypeId.Core/TypeId.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeId.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Unicode;
 
 namespace FastIDs.TypeId;
 
@@ -16,7 +17,7 @@ namespace FastIDs.TypeId;
 /// </code>
 /// </remarks>
 [StructLayout(LayoutKind.Auto)]
-public readonly struct TypeId : IEquatable<TypeId>
+public readonly struct TypeId : IEquatable<TypeId>, ISpanFormattable, IUtf8SpanFormattable
 {
     private readonly string _str;
 
@@ -51,6 +52,45 @@ public readonly struct TypeId : IEquatable<TypeId>
     /// </summary>
     /// <returns>A string representation of the TypeId.</returns>
     public override string ToString() => _str;
+
+    /// <summary>
+    /// Returns a string representation of the TypeId.
+    /// </summary>
+    /// <param name="format">Format string. Can be empty.</param>
+    /// <param name="formatProvider">Format provider. Can be null.</param>
+    /// <returns>Formatted string representation of the TypeId.</returns>
+    /// <remarks>
+    /// This method ignores <paramref name="format"/> and <paramref name="formatProvider"/> parameters and outputs the same result as <see cref="ToString()"/>.
+    /// </remarks>
+    public string ToString(string? format, IFormatProvider? formatProvider) => ToString();
+
+    /// <summary>
+    /// Tries to format the value of the current instance into the provided span of characters.
+    /// </summary>
+    /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+    /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+    /// <param name="format">A span containing the characters that represent a standard or custom format string. Can be empty.</param>
+    /// <param name="provider">Format provider. Can be null.</param>
+    /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// This method ignores <paramref name="format"/> and <paramref name="provider"/> parameters.
+    /// </remarks>
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) => 
+        destination.TryWrite($"{_str}", out charsWritten);
+
+    /// <summary>
+    /// Tries to format the value of the current instance into the provided span of bytes in UTF-8 encoding.
+    /// </summary>
+    /// <param name="utf8Destination">The span in which to write this instance's value formatted as a span of bytes in UTF-8 encoding.</param>
+    /// <param name="bytesWritten">When this method returns, contains the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
+    /// <param name="format">A span containing the characters that represent a standard or custom format string. Can be empty.</param>
+    /// <param name="provider">Format provider. Can be null.</param>
+    /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// This method ignores <paramref name="format"/> and <paramref name="provider"/> parameters.
+    /// </remarks>
+    public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider) => 
+        Utf8.TryWrite(utf8Destination, $"{_str}", out bytesWritten);
 
     /// <summary>
     /// A type component of the TypeId.

--- a/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/FormattingTests.cs
+++ b/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/FormattingTests.cs
@@ -38,6 +38,36 @@ public class FormattingTests
 
         typeId.ToString().Should().Be(typeIdStr);
     }
+    
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
+    public void Encoded_ToStringFormat(string typeIdStr, Guid expectedGuid, string expectedType)
+    {
+        var typeId = TypeId.Parse(typeIdStr);
+
+        typeId.ToString("", null).Should().Be(typeIdStr);
+    }
+    
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
+    public void Encoded_TryFormat(string typeIdStr, Guid expectedGuid, string expectedType)
+    {
+        var typeId = TypeId.Parse(typeIdStr);
+        
+        Span<char> formattedTypeId = stackalloc char[typeIdStr.Length + 10];
+        typeId.TryFormat(formattedTypeId, out var charsWritten, "", null).Should().BeTrue();
+
+        formattedTypeId[..charsWritten].ToString().Should().Be(typeIdStr);
+    }
+    
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
+    public void Encoded_TryFormatUtf8(string typeIdStr, Guid expectedGuid, string expectedType)
+    {
+        var typeId = TypeId.Parse(typeIdStr);
+        
+        Span<byte> formattedTypeId = stackalloc byte[typeIdStr.Length + 10];
+        typeId.TryFormat(formattedTypeId, out var bytesWritten, "", null).Should().BeTrue();
+
+        Encoding.UTF8.GetString(formattedTypeId[..bytesWritten]).Should().Be(typeIdStr);
+    }
 
     [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
     public void Decoded_GetSuffix(string typeIdStr, Guid expectedGuid, string expectedType)

--- a/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/FormattingTests.cs
+++ b/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/FormattingTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
+using System.Text.Unicode;
 using FastIDs.TypeId;
 using FluentAssertions;
 
@@ -62,10 +64,55 @@ public class FormattingTests
     }
     
     [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
+    public void Decoded_GetSuffixUtf8Span(string typeIdStr, Guid expectedGuid, string expectedType)
+    {
+        var decoded = TypeId.FromUuidV7(expectedType, expectedGuid);
+        
+        var expectedSuffix = typeIdStr.Split('_')[^1];
+    
+        Span<byte> utf8Suffix = stackalloc byte[expectedSuffix.Length + 10];
+        var bytesWritten = decoded.GetSuffix(utf8Suffix);
+        
+        bytesWritten.Should().Be(expectedSuffix.Length);
+        var suffix = Encoding.UTF8.GetString(utf8Suffix[..bytesWritten]);
+        suffix.Should().Be(expectedSuffix);
+    }
+    
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
     public void Decoded_ToString(string typeIdStr, Guid expectedGuid, string expectedType)
     {
         var decoded = TypeId.FromUuidV7(expectedType, expectedGuid);
 
         decoded.ToString().Should().Be(typeIdStr);
+    }
+
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
+    public void Decoded_ToStringFormat(string typeIdStr, Guid expectedGuid, string expectedType)
+    {
+        var decoded = TypeId.FromUuidV7(expectedType, expectedGuid);
+
+        decoded.ToString("", null).Should().Be(typeIdStr);
+    }
+    
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
+    public void Decoded_TryFormat(string typeIdStr, Guid expectedGuid, string expectedType)
+    {
+        var decoded = TypeId.FromUuidV7(expectedType, expectedGuid);
+
+        Span<char> formattedTypeId = stackalloc char[typeIdStr.Length + 10];
+        decoded.TryFormat(formattedTypeId, out var charsWritten, "", null).Should().BeTrue();
+
+        formattedTypeId[..charsWritten].ToString().Should().Be(typeIdStr);
+    }
+    
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.ValidIds))]
+    public void Decoded_TryFormatUtf8(string typeIdStr, Guid expectedGuid, string expectedType)
+    {
+        var decoded = TypeId.FromUuidV7(expectedType, expectedGuid);
+
+        Span<byte> formattedTypeId = stackalloc byte[typeIdStr.Length + 10];
+        decoded.TryFormat(formattedTypeId, out var bytesWritten, "", null).Should().BeTrue();
+
+        Encoding.UTF8.GetString(formattedTypeId[..bytesWritten]).Should().Be(typeIdStr);
     }
 }


### PR DESCRIPTION
`ISpanFormattable` and `IUtf8SpanFormattable` are used for efficient string interpolation. 