### PR TITLE
IComparable implementation

### DIFF
--- a/src/FastIDs.TypeId/TypeId.Core/AssemblyInfo.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("TypeId.Tests")]

--- a/src/FastIDs.TypeId/TypeId.Core/TypeId.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeId.cs
@@ -17,7 +17,7 @@ namespace FastIDs.TypeId;
 /// </code>
 /// </remarks>
 [StructLayout(LayoutKind.Auto)]
-public readonly struct TypeId : IEquatable<TypeId>, ISpanFormattable, IUtf8SpanFormattable
+public readonly struct TypeId : IEquatable<TypeId>, ISpanFormattable, IUtf8SpanFormattable, IComparable<TypeId>, IComparable
 {
     private readonly string _str;
 
@@ -257,6 +257,18 @@ public readonly struct TypeId : IEquatable<TypeId>, ISpanFormattable, IUtf8SpanF
     public static bool operator ==(TypeId left, TypeId right) => left.Equals(right);
 
     public static bool operator !=(TypeId left, TypeId right) => !left.Equals(right);
+    
+    public int CompareTo(TypeId other) => string.Compare(_str, other._str, StringComparison.Ordinal);
+
+    public int CompareTo(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) 
+            return 1;
+        
+        return obj is TypeId other 
+            ? CompareTo(other) 
+            : throw new ArgumentException($"Object must be of type {nameof(TypeId)}");
+    }
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/FastIDs.TypeId/TypeId.Core/TypeIdDecoded.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeIdDecoded.cs
@@ -250,4 +250,26 @@ public readonly struct TypeIdDecoded : IEquatable<TypeIdDecoded>, ISpanFormattab
     public static TypeIdDecoded FromUuidV7(string type, Guid uuidV7, bool validateType) => validateType
         ? FromUuidV7(type, uuidV7)
         : new TypeIdDecoded(type, uuidV7);
+ 
+    /// <summary>
+    /// Pre-defined comparers for <see cref="TypeIdDecoded"/>.
+    /// </summary>
+    public static class Comparers
+    {
+        /// <summary>
+        /// Compares two TypeIdDecoded instances lexicographically.
+        /// </summary>
+        /// <remarks>
+        /// TypeID components are compared in the following order: type, timestamp, and random part of the ID.
+        /// </remarks>
+        public static IComparer<TypeIdDecoded> Lex => TypeIdDecodedLexComparer.Instance;
+    
+        /// <summary>
+        /// Compares two TypeIdDecoded instances by the timestamp part of the ID.
+        /// </summary>
+        /// <remarks>
+        /// TypeID components are compared in the following order: timestamp, random part of the ID, and the type.
+        /// </remarks>
+        public static IComparer<TypeIdDecoded> Timestamp => TypeIdDecodedTimestampComparer.Instance;
+    }
 }

--- a/src/FastIDs.TypeId/TypeId.Core/TypeIdDecodedComparers.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeIdDecodedComparers.cs
@@ -1,0 +1,31 @@
+﻿using FastIDs.TypeId.Uuid;
+
+namespace FastIDs.TypeId;
+
+public class TypeIdDecodedLexComparer : IComparer<TypeIdDecoded>
+{
+    public static TypeIdDecodedLexComparer Instance { get; } = new();
+    
+    public int Compare(TypeIdDecoded x, TypeIdDecoded y)
+    {
+        var typeComparison = string.CompareOrdinal(x.Type, y.Type);
+        if (typeComparison != 0) 
+            return typeComparison;
+
+        return UuidComparer.Instance.Compare(x.Id, y.Id);
+    }
+}
+
+public class TypeIdDecodedTimestampComparer : IComparer<TypeIdDecoded>
+{
+    public static TypeIdDecodedTimestampComparer Instance { get; } = new();
+    
+    public int Compare(TypeIdDecoded x, TypeIdDecoded y)
+    {
+        var idComparison = UuidComparer.Instance.Compare(x.Id, y.Id);
+        if (idComparison != 0)
+            return idComparison;
+
+        return string.CompareOrdinal(x.Type, y.Type);
+    }
+}

--- a/src/FastIDs.TypeId/TypeId.Core/Uuid/UuidComparer.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/Uuid/UuidComparer.cs
@@ -1,10 +1,12 @@
 ﻿namespace FastIDs.TypeId.Uuid;
 
 /// <summary>
-/// Compares two UUIDv7 implementations in <see cref="Guid"/>
+/// Compares two big endian <see cref="Guid"/>
 /// </summary>
 internal class UuidComparer : IComparer<Guid>
 {
+    public static UuidComparer Instance { get; } = new();
+    
     public int Compare(Guid x, Guid y)
     {
         const int bytesCount = 16;

--- a/src/FastIDs.TypeId/TypeId.Core/Uuid/UuidComparer.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/Uuid/UuidComparer.cs
@@ -1,0 +1,26 @@
+﻿namespace FastIDs.TypeId.Uuid;
+
+/// <summary>
+/// Compares two UUIDv7 implementations in <see cref="Guid"/>
+/// </summary>
+internal class UuidComparer : IComparer<Guid>
+{
+    public int Compare(Guid x, Guid y)
+    {
+        const int bytesCount = 16;
+        Span<byte> xBytes = stackalloc byte[bytesCount];
+        x.TryWriteBytes(xBytes, bigEndian: true, out _);
+
+        Span<byte> yBytes = stackalloc byte[bytesCount];
+        y.TryWriteBytes(yBytes, bigEndian: true, out _);
+
+        for (var i = 0; i < bytesCount; i++)
+        {
+            var compareResult = xBytes[i].CompareTo(yBytes[i]);
+            if (compareResult != 0)
+                return compareResult;
+        }
+
+        return 0;
+    }
+}

--- a/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
+++ b/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
@@ -30,9 +30,8 @@ public class ComparisonTests
     {
         var first = TypeId.New("aaa");
         var second = TypeId.New("aaa");
-        var comparer = new UuidComparer();
 
-        var result = comparer.Compare(first.Id, second.Id);
+        var result = UuidComparer.Instance.Compare(first.Id, second.Id);
         result.Should().BeLessThan(0);
     }
     
@@ -41,9 +40,8 @@ public class ComparisonTests
     {
         var first = TypeId.New("aaa");
         var second = TypeId.New("aaa");
-        var comparer = new UuidComparer();
 
-        var result = comparer.Compare(second.Id, first.Id);
+        var result = UuidComparer.Instance.Compare(second.Id, first.Id);
         result.Should().BeGreaterThan(0);
     }
     
@@ -51,9 +49,8 @@ public class ComparisonTests
     public void UuidV7_SameTimestamps_IdsAreEqual()
     {
         var first = TypeId.New("aaa");
-        var comparer = new UuidComparer();
 
-        var result = comparer.Compare(first.Id, first.Id);
+        var result = UuidComparer.Instance.Compare(first.Id, first.Id);
         result.Should().Be(0);
     }
 }

--- a/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
+++ b/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
@@ -1,0 +1,26 @@
+﻿using FastIDs.TypeId;
+using FluentAssertions;
+
+namespace TypeIdTests.TypeIdTests;
+
+[TestFixture]
+public class ComparisonTests
+{
+    [Test]
+    public void TypeId_DifferentPrefix_PrefixesComparedLexicographically()
+    {
+        var first = TypeId.New("bbb").Encode();
+        var second = TypeId.New("aaa").Encode();
+
+        first.Should().BeGreaterThan(second);
+    }
+    
+    [Test]
+    public void TypeId_SamePrefix_OlderIdIsLessThanNewer()
+    {
+        var first = TypeId.New("aaa").Encode();
+        var second = TypeId.New("aaa").Encode();
+
+        first.Should().BeLessThan(second);
+    }
+}

--- a/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
+++ b/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
@@ -1,4 +1,5 @@
 ﻿using FastIDs.TypeId;
+using FastIDs.TypeId.Uuid;
 using FluentAssertions;
 
 namespace TypeIdTests.TypeIdTests;
@@ -22,5 +23,37 @@ public class ComparisonTests
         var second = TypeId.New("aaa").Encode();
 
         first.Should().BeLessThan(second);
+    }
+
+    [Test]
+    public void UuidV7_DifferentTimestamps_OlderIdIsLessThanNewer()
+    {
+        var first = TypeId.New("aaa");
+        var second = TypeId.New("aaa");
+        var comparer = new UuidComparer();
+
+        var result = comparer.Compare(first.Id, second.Id);
+        result.Should().BeLessThan(0);
+    }
+    
+    [Test]
+    public void UuidV7_DifferentTimestamps_NewerIsGreaterThanOlder()
+    {
+        var first = TypeId.New("aaa");
+        var second = TypeId.New("aaa");
+        var comparer = new UuidComparer();
+
+        var result = comparer.Compare(second.Id, first.Id);
+        result.Should().BeGreaterThan(0);
+    }
+    
+    [Test]
+    public void UuidV7_SameTimestamps_IdsAreEqual()
+    {
+        var first = TypeId.New("aaa");
+        var comparer = new UuidComparer();
+
+        var result = comparer.Compare(first.Id, first.Id);
+        result.Should().Be(0);
     }
 }

--- a/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
+++ b/src/FastIDs.TypeId/TypeId.Tests/TypeIdTests/ComparisonTests.cs
@@ -1,4 +1,5 @@
-﻿using FastIDs.TypeId;
+﻿using System;
+using FastIDs.TypeId;
 using FastIDs.TypeId.Uuid;
 using FluentAssertions;
 
@@ -53,4 +54,48 @@ public class ComparisonTests
         var result = UuidComparer.Instance.Compare(first.Id, first.Id);
         result.Should().Be(0);
     }
+
+    [TestCase("bbb", "aaa", 1)]
+    [TestCase("aaa", "bbb", -1)]
+    public void TypeIdDecodedLexComparer_DifferentPrefix_TypesComparedLexicographically(string firstPrefix, string secondPrefix, int expected)
+    {
+        var first = TypeIdDecoded.New(firstPrefix);
+        var second = TypeIdDecoded.New(secondPrefix);
+
+        var result = TypeIdDecoded.Comparers.Lex.Compare(first, second);
+        result.Should().Be(expected);
+    }
+    
+    [Test]
+    public void TypeIdDecodedLexComparer_SamePrefix_OlderIdIsLessThanNewer()
+    {
+        var first = TypeIdDecoded.New("aaa");
+        var second = TypeIdDecoded.New("aaa");
+
+        var result = TypeIdDecoded.Comparers.Lex.Compare(first, second);
+        result.Should().BeLessThan(0);
+    }
+    
+    [Test]
+    public void TypeIdDecodedTimestampComparer_DifferentTimestamps_OlderIdIsLessThanNewer()
+    {
+        var first = TypeIdDecoded.New("aaa");
+        var second = TypeIdDecoded.New("aaa");
+
+        var result = TypeIdDecoded.Comparers.Timestamp.Compare(first, second);
+        result.Should().BeLessThan(0);
+    }
+    
+    [TestCase("aaa", "bbb", -1)]
+    [TestCase("bbb", "aaa", 1)]
+    [TestCase("aaa", "aaa", 0)]
+    public void TypeIdDecodedTimestampComparer_SameUuidv7_TypeIsComparedLexicographically(string firstPrefix, string secondPrefix, int expected)
+    {
+        var first = TypeIdDecoded.FromUuidV7(firstPrefix, Guid.Parse("01953e9c-1f53-771b-a158-cb2c3c59bed4"));
+        var second = TypeIdDecoded.FromUuidV7(secondPrefix, Guid.Parse("01953e9c-1f53-771b-a158-cb2c3c59bed4"));
+
+        var result = TypeIdDecoded.Comparers.Timestamp.Compare(first, second);
+        result.Should().Be(expected);
+    }
+    
 }


### PR DESCRIPTION
Addresses #29

- Implemented `IComparable` for `TypeId`.
- Added 2 pre-defined comparers for `TypeIdDecoded`:
  - `Lex` - compares components in order: `type -> timestamp -> random_part`
  - `Timestamp` - compares components in order: `timestamp -> random_part -> type`