### PR TITLE
FormatExceptions in JsonConverters are rethrown as JsonException

### DIFF
--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDecodedDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDecodedDeserializationTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+
+namespace FastIDs.TypeId.Serialization.JsonNet.Tests;
+
+[TestFixture]
+public class TypeIdDecodedDeserializationTests
+{
+    private readonly JsonSerializerSettings _settings = new JsonSerializerSettings().ConfigureForTypeId();
+    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L";  // 'L' is not valid base32
+    
+    [Test]
+    public void TypeId_ParsingError_ShouldBeConvertedToJsonException()
+    {
+        // arrange
+        const string json = $$"""
+            {
+                "Id": "{{InvalidTypeIdStr}}",
+                "Value": 123 
+            }
+            """;
+
+        // act
+        var act = () => JsonConvert.DeserializeObject<TypeIdDecodedContainer>(json, _settings);
+
+        // assert
+        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+    }
+    
+    private record TypeIdDecodedContainer(TypeIdDecoded Id, int Value);
+}

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDecodedDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDecodedDeserializationTests.cs
@@ -7,8 +7,8 @@ namespace FastIDs.TypeId.Serialization.JsonNet.Tests;
 public class TypeIdDecodedDeserializationTests
 {
     private readonly JsonSerializerSettings _settings = new JsonSerializerSettings().ConfigureForTypeId();
-    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L";  // 'L' is not valid base32
-    
+    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L"; // 'L' is not valid base32
+
     [Test]
     public void TypeId_ParsingError_ShouldBeConvertedToJsonException()
     {
@@ -24,8 +24,12 @@ public class TypeIdDecodedDeserializationTests
         var act = () => JsonConvert.DeserializeObject<TypeIdDecodedContainer>(json, _settings);
 
         // assert
-        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+        act.Should()
+            .Throw<JsonSerializationException>()
+            .Where(x => x.LineNumber == 2)
+            .Where(x => x.LinePosition > 0)
+            .WithInnerException<FormatException>();
     }
-    
+
     private record TypeIdDecodedContainer(TypeIdDecoded Id, int Value);
 }

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDeserializationTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+
+namespace FastIDs.TypeId.Serialization.JsonNet.Tests;
+
+[TestFixture]
+public class TypeIdDeserializationTests
+{
+    private readonly JsonSerializerSettings _settings = new JsonSerializerSettings().ConfigureForTypeId();
+    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L";  // 'L' is not valid base32
+    
+    [Test]
+    public void TypeId_ParsingError_ShouldBeConvertedToJsonException()
+    {
+        // arrange
+        const string json = $$"""
+            {
+                "Id": "{{InvalidTypeIdStr}}",
+                "Value": 123 
+            }
+            """;
+
+        // act
+        var act = () => JsonConvert.DeserializeObject<TypeIdContainer>(json, _settings);
+
+        // assert
+        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+    }
+    
+    private record TypeIdContainer(TypeId Id, int Value);
+}

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet.Tests/TypeIdDeserializationTests.cs
@@ -7,8 +7,8 @@ namespace FastIDs.TypeId.Serialization.JsonNet.Tests;
 public class TypeIdDeserializationTests
 {
     private readonly JsonSerializerSettings _settings = new JsonSerializerSettings().ConfigureForTypeId();
-    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L";  // 'L' is not valid base32
-    
+    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L"; // 'L' is not valid base32
+
     [Test]
     public void TypeId_ParsingError_ShouldBeConvertedToJsonException()
     {
@@ -24,8 +24,12 @@ public class TypeIdDeserializationTests
         var act = () => JsonConvert.DeserializeObject<TypeIdContainer>(json, _settings);
 
         // assert
-        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+        act.Should()
+            .Throw<JsonSerializationException>()
+            .Where(x => x.LineNumber == 2)
+            .Where(x => x.LinePosition > 0)
+            .WithInnerException<FormatException>();
     }
-    
+
     private record TypeIdContainer(TypeId Id, int Value);
 }

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/JsonSerializationExceptionFactory.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/JsonSerializationExceptionFactory.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace FastIDs.TypeId.Serialization.JsonNet;
+
+// Newtonsoft uses internal methods to populate exception details and won't make them public (see https://github.com/JamesNK/Newtonsoft.Json/pull/1963),
+// so they are duplicated for our use.
+internal static class JsonSerializationExceptionFactory
+{
+    // See https://github.com/JamesNK/Newtonsoft.Json/blob/8f579cf5970c57025237db4c7eae33ae4af289e3/Src/Newtonsoft.Json/JsonSerializationException.cs#L123
+    public static JsonSerializationException Create(JsonReader reader, string message, Exception? ex)
+    {
+        return Create(reader as IJsonLineInfo, reader.Path, message, ex);
+    }
+
+    public static JsonSerializationException Create(IJsonLineInfo? lineInfo, string path, string message, Exception? ex)
+    {
+        message = FormatMessage(lineInfo, path, message);
+        int lineNumber;
+        int linePosition;
+    
+        if (lineInfo != null && lineInfo.HasLineInfo())
+        {
+            lineNumber = lineInfo.LineNumber;
+            linePosition = lineInfo.LinePosition;
+        }
+        else
+        {
+            lineNumber = 0;
+            linePosition = 0;
+        }
+    
+        return new JsonSerializationException(message, path, lineNumber, linePosition, ex);
+    }
+    
+    // See https://github.com/JamesNK/Newtonsoft.Json/blob/8f579cf5970c57025237db4c7eae33ae4af289e3/Src/Newtonsoft.Json/JsonPosition.cs#L150
+    private static string FormatMessage(IJsonLineInfo? lineInfo, string path, string message)
+    {
+        // don't add a fullstop and space when message ends with a new line
+        if (!message.EndsWith(Environment.NewLine, StringComparison.Ordinal))
+        {
+            message = message.Trim();
+
+            if (!message.EndsWith('.'))
+            {
+                message += ".";
+            }
+
+            message += " ";
+        }
+
+        message += string.Format(CultureInfo.InvariantCulture, "Path '{0}'", path);
+
+        if (lineInfo != null && lineInfo.HasLineInfo())
+        {
+            message += string.Format(CultureInfo.InvariantCulture, ", line {0}, position {1}", lineInfo.LineNumber, lineInfo.LinePosition);
+        }
+
+        message += ".";
+
+        return message;
+    }
+}

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdConverter.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdConverter.cs
@@ -11,6 +11,13 @@ public class TypeIdConverter : JsonConverter<TypeId>
 
     public override TypeId ReadJson(JsonReader reader, Type objectType, TypeId existingValue, bool hasExistingValue, JsonSerializer serializer)
     {
-        return reader.Value is string val ? TypeId.Parse(val) : default;
+        try
+        {
+            return reader.Value is string val ? TypeId.Parse(val) : default;
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException(ex.Message, ex);
+        }
     }
 }

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdConverter.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdConverter.cs
@@ -17,7 +17,7 @@ public class TypeIdConverter : JsonConverter<TypeId>
         }
         catch (FormatException ex)
         {
-            throw new JsonException(ex.Message, ex);
+            throw JsonSerializationExceptionFactory.Create(reader, ex.Message, ex);
         }
     }
 }

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdDecodedConverter.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdDecodedConverter.cs
@@ -11,6 +11,13 @@ public class TypeIdDecodedConverter : JsonConverter<TypeIdDecoded>
 
     public override TypeIdDecoded ReadJson(JsonReader reader, Type objectType, TypeIdDecoded existingValue, bool hasExistingValue, JsonSerializer serializer)
     {
-        return reader.Value is string val ? TypeId.Parse(val).Decode() : default;
+        try
+        {
+            return reader.Value is string val ? TypeId.Parse(val).Decode() : default;
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException(ex.Message, ex);
+        }
     }
 }

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdDecodedConverter.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.JsonNet/TypeIdDecodedConverter.cs
@@ -17,7 +17,7 @@ public class TypeIdDecodedConverter : JsonConverter<TypeIdDecoded>
         }
         catch (FormatException ex)
         {
-            throw new JsonException(ex.Message, ex);
+            throw JsonSerializationExceptionFactory.Create(reader, ex.Message, ex);
         }
     }
 }

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDecodedDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDecodedDeserializationTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using FluentAssertions;
+
+namespace FastIDs.TypeId.Serialization.SystemTextJson.Tests;
+
+[TestFixture]
+public class TypeIdDecodedDeserializationTests
+{
+    private readonly JsonSerializerOptions _options = new JsonSerializerOptions().ConfigureForTypeId();
+    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L";  // 'L' is not valid base32
+    
+    [Test]
+    public void TypeId_ParsingErrorDuringRead_ShouldBeConvertedToJsonException()
+    {
+        // arrange
+        const string json = $$"""
+            {
+                "Id": "{{InvalidTypeIdStr}}",
+                "Value": 123 
+            }
+            """;
+
+        // act
+        var act = () => JsonSerializer.Deserialize<TypeIdDecodedContainer>(json, _options);
+
+        // assert
+        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+    }
+    
+    [Test]
+    public void TypeId_ParsingErrorDuringReadAsPropertyName_ShouldBeConvertedToJsonException()
+    {
+        // arrange
+        const string json = $$"""
+            {
+                "Id": "{{InvalidTypeIdStr}}",
+                "Value": 123 
+            }
+            """;
+
+        // act
+        var act = () => JsonSerializer.Deserialize<Dictionary<TypeIdDecoded, int>>(json, _options);
+
+        // assert
+        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+    }
+    
+    private record TypeIdDecodedContainer(TypeIdDecoded Id, int Value);
+}

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDecodedDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDecodedDeserializationTests.cs
@@ -24,7 +24,11 @@ public class TypeIdDecodedDeserializationTests
         var act = () => JsonSerializer.Deserialize<TypeIdDecodedContainer>(json, _options);
 
         // assert
-        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+        act.Should().Throw<JsonException>()
+            .Where(x => x.LineNumber == 1)
+            .Where(x => x.BytePositionInLine != null)
+            .Where(x => x.Path == "$.Id")
+            .WithInnerException<FormatException>();
     }
     
     [Test]
@@ -42,7 +46,11 @@ public class TypeIdDecodedDeserializationTests
         var act = () => JsonSerializer.Deserialize<Dictionary<TypeIdDecoded, int>>(json, _options);
 
         // assert
-        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+        act.Should().Throw<JsonException>()
+            .Where(x => x.LineNumber == 1)
+            .Where(x => x.BytePositionInLine != null)
+            .Where(x => x.Path == "$.Id")
+            .WithInnerException<FormatException>();
     }
     
     private record TypeIdDecodedContainer(TypeIdDecoded Id, int Value);

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDeserializationTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using FluentAssertions;
+
+namespace FastIDs.TypeId.Serialization.SystemTextJson.Tests;
+
+[TestFixture]
+public class TypeIdDeserializationTests
+{
+    private readonly JsonSerializerOptions _options = new JsonSerializerOptions().ConfigureForTypeId();
+    private const string InvalidTypeIdStr = "type_01h455vb4pex5vsknk084sn02L";  // 'L' is not valid base32
+    
+    [Test]
+    public void TypeId_ParsingErrorDuringRead_ShouldBeConvertedToJsonException()
+    {
+        // arrange
+        const string json = $$"""
+            {
+                "Id": "{{InvalidTypeIdStr}}",
+                "Value": 123 
+            }
+            """;
+
+        // act
+        var act = () => JsonSerializer.Deserialize<TypeIdContainer>(json, _options);
+
+        // assert
+        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+    }
+    
+    [Test]
+    public void TypeId_ParsingErrorDuringReadAsPropertyName_ShouldBeConvertedToJsonException()
+    {
+        // arrange
+        const string json = $$"""
+            {
+                "Id": "{{InvalidTypeIdStr}}",
+                "Value": 123 
+            }
+            """;
+
+        // act
+        var act = () => JsonSerializer.Deserialize<Dictionary<TypeId, int>>(json, _options);
+
+        // assert
+        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+    }
+    
+    private record TypeIdContainer(TypeId Id, int Value);
+}

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDeserializationTests.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson.Tests/TypeIdDeserializationTests.cs
@@ -24,7 +24,11 @@ public class TypeIdDeserializationTests
         var act = () => JsonSerializer.Deserialize<TypeIdContainer>(json, _options);
 
         // assert
-        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+        act.Should().Throw<JsonException>()
+            .Where(x => x.LineNumber == 1)
+            .Where(x => x.BytePositionInLine != null)
+            .Where(x => x.Path == "$.Id")
+            .WithInnerException<FormatException>();
     }
     
     [Test]
@@ -42,7 +46,11 @@ public class TypeIdDeserializationTests
         var act = () => JsonSerializer.Deserialize<Dictionary<TypeId, int>>(json, _options);
 
         // assert
-        act.Should().Throw<JsonException>().WithInnerException<FormatException>();
+        act.Should().Throw<JsonException>()
+            .Where(x => x.LineNumber == 1)
+            .Where(x => x.BytePositionInLine != null)
+            .Where(x => x.Path == "$.Id")
+            .WithInnerException<FormatException>();
     }
     
     private record TypeIdContainer(TypeId Id, int Value);

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson/TypeIdConverter.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson/TypeIdConverter.cs
@@ -8,7 +8,14 @@ public class TypeIdConverter : JsonConverter<TypeId>
     public override TypeId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var val = reader.GetString();
-        return val is not null ? TypeId.Parse(val) : default;
+        try
+        {
+            return val is not null ? TypeId.Parse(val) : default;
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException(ex.Message, ex);
+        }
     }
 
     public override void Write(Utf8JsonWriter writer, TypeId value, JsonSerializerOptions options)
@@ -24,6 +31,13 @@ public class TypeIdConverter : JsonConverter<TypeId>
     public override TypeId ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var val = reader.GetString();
-        return val is not null ? TypeId.Parse(val) : default;
+        try
+        {
+            return val is not null ? TypeId.Parse(val) : default;
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException(ex.Message, ex);
+        }
     }
 }

--- a/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson/TypeIdDecodedConverter.cs
+++ b/src/FastIDs.TypeId.Serialization/TypeId.Serialization.SystemTextJson/TypeIdDecodedConverter.cs
@@ -38,7 +38,14 @@ public class TypeIdDecodedConverter : JsonConverter<TypeIdDecoded>
     private static TypeIdDecoded ReadTypeId(ref Utf8JsonReader reader)
     {
         var val = reader.GetString();
-        return val is not null ? TypeId.Parse(val).Decode() : default;
+        try
+        {
+            return val is not null ? TypeId.Parse(val).Decode() : default;
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException(ex.Message, ex);
+        }
     }
 
     private static void CopyValueToBuffer(in TypeIdDecoded value, Span<char> buffer)


### PR DESCRIPTION
This allows the error to be reported correctly as a problem with deserializing the input (yielding a 400 response) rather than being treated as an unhandled exception that will yield a 500 server error response.