### PR TITLE
Add full support for comparison operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,16 @@ Both `TypeId` and `TypeIdDecoded` have the same API for checking if the type equ
 bool isSameType = typeId.HasType("your_type"); // also has overload for ReadOnlySpan<char>
 ```
 
-### Equality
+### Equality and Comparisons
 
 Both `TypeId` and `TypeIdDecoded` structs implement the `IEquatable<T>` interface with all its benefits:
 * `typeId.Equals(other)` or `typeId == other` to check if IDs are same.
 * `!typeId.Equals(other)` or `typeId != other` to check if IDs are different.
 * Use `TypeId` as a key in `Dictionary` or `HashSet`.
+
+`TypeId` and `TypeIdDecoded` also implement `IComparable<T>` and the comparison operators `< > <= >=`.  `TypeId` always 
+uses lexographic comparison.  `TypeIdDecoded` uses a lexographic comparer by default, but you can choose to use the timestamp
+based comparer by setting `TypeIdDecoded.Comparer = Comparers.Timestamp` in your application startup code.
 
 ### UUIDv7 component operations
 

--- a/src/FastIDs.TypeId/TypeId.Core/TypeId.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeId.cs
@@ -258,6 +258,14 @@ public readonly struct TypeId : IEquatable<TypeId>, ISpanFormattable, IUtf8SpanF
 
     public static bool operator !=(TypeId left, TypeId right) => !left.Equals(right);
     
+    public static bool operator <(TypeId left, TypeId right) => left.CompareTo(right) < 0;
+    
+    public static bool operator <=(TypeId left, TypeId right) => left.CompareTo(right) <= 0;
+    
+    public static bool operator >(TypeId left, TypeId right) => left.CompareTo(right) > 0;
+    
+    public static bool operator >=(TypeId left, TypeId right) => left.CompareTo(right) >= 0;
+    
     public int CompareTo(TypeId other) => string.Compare(_str, other._str, StringComparison.Ordinal);
 
     public int CompareTo(object? obj)

--- a/src/FastIDs.TypeId/TypeId.Core/TypeIdDecoded.cs
+++ b/src/FastIDs.TypeId/TypeId.Core/TypeIdDecoded.cs
@@ -5,9 +5,17 @@ using FastIDs.TypeId.Uuid;
 namespace FastIDs.TypeId;
 
 [StructLayout(LayoutKind.Auto)]
-public readonly struct TypeIdDecoded : IEquatable<TypeIdDecoded>, ISpanFormattable, IUtf8SpanFormattable
+public readonly struct TypeIdDecoded : IEquatable<TypeIdDecoded>, ISpanFormattable, IUtf8SpanFormattable, IComparable<TypeIdDecoded>, IComparable
 {
+    private static IComparer<TypeIdDecoded> ComparerValue = Comparers.Lex;
     private static readonly UuidGenerator UuidGenerator = new();
+
+    public static IComparer<TypeIdDecoded> Comparer
+    {
+        get => ComparerValue;
+        set => ComparerValue = value ?? throw new ArgumentNullException(nameof(value));
+        
+    }
     
     /// <summary>
     /// The type part of the TypeId.
@@ -180,11 +188,31 @@ public readonly struct TypeIdDecoded : IEquatable<TypeIdDecoded>, ISpanFormattab
 
     public override bool Equals(object? obj) => obj is TypeIdDecoded other && Equals(other);
 
+    public int CompareTo(TypeIdDecoded other) => ComparerValue.Compare(this, other);
+
+    public int CompareTo(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) 
+            return 1;
+        
+        return obj is TypeIdDecoded other 
+            ? CompareTo(other) 
+            : throw new ArgumentException($"Object must be of type {nameof(TypeIdDecoded)}");
+    }
+
     public override int GetHashCode() => HashCode.Combine(Type, Id);
 
     public static bool operator ==(TypeIdDecoded left, TypeIdDecoded right) => left.Equals(right);
 
     public static bool operator !=(TypeIdDecoded left, TypeIdDecoded right) => !left.Equals(right);
+    
+    public static bool operator <(TypeIdDecoded left, TypeIdDecoded right) => left.CompareTo(right) < 0;
+    
+    public static bool operator <=(TypeIdDecoded left, TypeIdDecoded right) => left.CompareTo(right) < 0;
+    
+    public static bool operator >(TypeIdDecoded left, TypeIdDecoded right) => left.CompareTo(right) > 0;
+    
+    public static bool operator >=(TypeIdDecoded left, TypeIdDecoded right) => left.CompareTo(right) >= 0;
 
     /// <summary>
     /// Generates new TypeId with the specified type and random UUIDv7.


### PR DESCRIPTION
Sortability is one of the main features advertised by the TypeId spec, so I feel like both `TypeId` and `TypeIdDecoded` should support comparisons (and therefore sorting).

However what's more important to me personally 😉 is that the operators are needed to support Entity Framework LINQ queries.  Even though the underlying uuid column supports the comparison operations, you can't write a LINQ query unless the C# struct has those operators.