### PR TITLE
Add .net 8 support for TypeSafeId benchmarks

### DIFF
--- a/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdComparison.cs
+++ b/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdComparison.cs
@@ -19,9 +19,7 @@ public class TypeIdComparison
     private TypeIdDecoded[] _fastIdTypeIdsDecoded = Array.Empty<TypeIdDecoded>();
     private TcKs.TypeId.TypeId[] _tcKsTypeIds = Array.Empty<TcKs.TypeId.TypeId>();
     private global::TypeId.TypeId[] _cbuctokTypeIds = Array.Empty<global::TypeId.TypeId>();
-#if NET10_0_OR_GREATER
     private TypeSafeId.TypeId<Entity>[] _typeSafeIds = Array.Empty<TypeSafeId.TypeId<Entity>>();
-#endif
 
     private readonly string _prefixFull;
 
@@ -45,9 +43,7 @@ public class TypeIdComparison
             ? $"{prefix}_{_suffix}"
             : _suffix;
 
-#if NET10_0_OR_GREATER
         TypeSafeId.TypeId<Entity>.SetPrefix(prefix);
-#endif
 
         _fastIdTypeIds = new[] { TypeId.Parse(typeIdStr), TypeId.Parse(typeIdStr) };
         _fastIdTypeIdsDecoded = new[] { TypeId.Parse(typeIdStr).Decode(), TypeId.Parse(typeIdStr).Decode() };
@@ -59,9 +55,7 @@ public class TypeIdComparison
         }
 
         _cbuctokTypeIds = new[] { global::TypeId.TypeId.Parse(typeIdStr), global::TypeId.TypeId.Parse(typeIdStr) };
-#if NET10_0_OR_GREATER
         _typeSafeIds = new[] { TypeSafeId.TypeId<Entity>.Parse(typeIdStr), TypeSafeId.TypeId<Entity>.Parse(typeIdStr) };
-#endif
     }
 
     [Benchmark(Baseline = true)]
@@ -80,11 +74,9 @@ public class TypeIdComparison
     [BenchmarkCategory("Equality")]
     public bool CbuctokEquals() => _cbuctokTypeIds[0] == _cbuctokTypeIds[1];
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     [BenchmarkCategory("Equality")]
     public bool TypeSafeIdEquals() => _typeSafeIds[0] == _typeSafeIds[1];
-#endif
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("HashCode")]
@@ -102,11 +94,9 @@ public class TypeIdComparison
     [BenchmarkCategory("HashCode")]
     public int CbuctokHash() => _cbuctokTypeIds[0].GetHashCode();
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     [BenchmarkCategory("HashCode")]
     public int TypeSafeIdHash() => _typeSafeIds[0].GetHashCode();
-#endif
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Prefix")]
@@ -128,11 +118,9 @@ public class TypeIdComparison
     [BenchmarkCategory("Prefix")]
     public string CbuctokPrefix() => _cbuctokTypeIds[0].Type;
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     [BenchmarkCategory("Prefix")]
     public string TypeSafeIdPrefix() => TypeSafeId.TypeId<Entity>.Prefix;
-#endif
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Id")]
@@ -150,11 +138,9 @@ public class TypeIdComparison
     [BenchmarkCategory("Id")]
     public string CbuctokId() => _cbuctokTypeIds[0].Id;
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     [BenchmarkCategory("Id")]
     public Guid TypeSafeIdId() => _typeSafeIds[0].Uuid;
-#endif
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Suffix")]
@@ -172,7 +158,6 @@ public class TypeIdComparison
     [BenchmarkCategory("Suffix")]
     public string TcKsSuffix() => _tcKsTypeIds[0].Suffix;
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     [BenchmarkCategory("Suffix")]
     public string TypeSafeIdSuffix() => _typeSafeIds[0].GetSuffix();
@@ -186,5 +171,4 @@ public class TypeIdComparison
     }
 
     public record Entity;
-#endif
 }

--- a/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdGeneration.cs
+++ b/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdGeneration.cs
@@ -31,9 +31,7 @@ public class TypeIdGeneration
     {
         _prefix = _prefixFull[..PrefixLength];
 
-#if NET10_0_OR_GREATER
         TypeSafeId.TypeId<Entity>.SetPrefix(_prefix);
-#endif
     }
 
     [Benchmark(Baseline = true)]
@@ -60,13 +58,11 @@ public class TypeIdGeneration
         return global::TypeId.TypeId.NewTypeId(_prefix);
     }
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     public TypeSafeId.TypeId<Entity> TypeSafeIdBenchmark()
     {
-        return TypeSafeId.TypeId<Entity>.Create();
+        return TypeSafeId.TypeId.Create<Entity>();
     }
 
     public record Entity;
-#endif
 }

--- a/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdParsing.cs
+++ b/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdParsing.cs
@@ -36,9 +36,7 @@ public class TypeIdParsing
         var prefix = _prefixFull[..PrefixLength];
         _typeIdString = TypeId.FromUuidV7(prefix, _uuidV7).ToString();
 
-#if NET10_0_OR_GREATER
         TypeSafeId.TypeId<Entity>.SetPrefix(prefix);
-#endif
     }
 
     [Benchmark(Baseline = true)]
@@ -80,7 +78,6 @@ public class TypeIdParsing
         return typeId;
     }
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     public TypeSafeId.TypeId<Entity> TypeSafeIdParse()
     {
@@ -95,5 +92,4 @@ public class TypeIdParsing
     }
 
     public record Entity;
-#endif
 }

--- a/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdRetrieveFlow.cs
+++ b/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdRetrieveFlow.cs
@@ -35,9 +35,7 @@ public class TypeIdRetrieveFlow
         var prefix = _prefixFull[..PrefixLength];
         _typeIdString = TypeId.FromUuidV7(prefix, _uuidV7).ToString();
 
-#if NET10_0_OR_GREATER
         TypeSafeId.TypeId<Entity>.SetPrefix(prefix);
-#endif
     }
     
     [Benchmark(Baseline = true)]
@@ -69,7 +67,6 @@ public class TypeIdRetrieveFlow
         return typeId.ToString();
     }
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     public string TypeSafeIdBenchmark()
     {
@@ -78,5 +75,4 @@ public class TypeIdRetrieveFlow
     }
 
     public record Entity;
-#endif
 }

--- a/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdString.cs
+++ b/src/FastIDs.TypeId/TypeId.Benchmarks/LibraryComparison/TypeIdString.cs
@@ -18,9 +18,7 @@ public class TypeIdString
     private TypeIdDecoded _fastIdTypeIdDecoded;
     private TcKs.TypeId.TypeId _tcKsTypeId;
     private global::TypeId.TypeId _cbuctokTypeId;
-#if NET10_0_OR_GREATER
     private TypeSafeId.TypeId<Entity> _typeSafeIdTypeId;
-#endif
     
     public TypeIdString()
     {
@@ -45,11 +43,9 @@ public class TypeIdString
         _fastIdTypeId = _fastIdTypeIdDecoded.Encode();
         _tcKsTypeId = new TcKs.TypeId.TypeId(prefix, _uuidV7);
         _cbuctokTypeId = new global::TypeId.TypeId(prefix, _uuidV7);
-#if NET10_0_OR_GREATER
         _typeSafeIdTypeId = new TypeSafeId.TypeId<Entity>(_uuidV7);
 
         global::TypeSafeId.TypeId<Entity>.SetPrefix(prefix);
-#endif
     }
 
     [Benchmark(Baseline = true)]
@@ -76,7 +72,6 @@ public class TypeIdString
         return _cbuctokTypeId.ToString();
     }
 
-#if NET10_0_OR_GREATER
     [Benchmark]
     public string TypeSafeId()
     {
@@ -84,5 +79,4 @@ public class TypeIdString
     }
 
     public record Entity;
-#endif
 }

--- a/src/FastIDs.TypeId/TypeId.Benchmarks/TypeId.Benchmarks.csproj
+++ b/src/FastIDs.TypeId/TypeId.Benchmarks/TypeId.Benchmarks.csproj
@@ -13,10 +13,7 @@
       <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
       <PackageReference Include="Evgreg.TypeId" Version="1.0.3" />
       <PackageReference Include="TcKs.TypeId" Version="1.3.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-      <PackageReference Include="TypeSafeId" Version="1.2.0" />
+      <PackageReference Include="TypeSafeId" Version="1.3.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Follow up for #37.